### PR TITLE
Fix a typo I noticed in the videos page.

### DIFF
--- a/site/Docs/Start-Here/Videos.markdown
+++ b/site/Docs/Start-Here/Videos.markdown
@@ -15,7 +15,7 @@
 ###[mvcConf 2 - Phil Haack: The NuGet-y Goodness of Delivering Packages](http://channel9.msdn.com/Series/mvcConf/mvcConf-2-Phil-Haack-The-NuGet-y-Goodness-of-Delivering-Packages)
 <iframe style="height:288px;width:512px" src="http://channel9.msdn.com/Series/mvcConf/mvcConf-2-Phil-Haack-The-NuGet-y-Goodness-of-Delivering-Packages/player?w=512&h=288" frameBorder="0" scrolling="no" ></iframe>
 
-###[mvcConf 2 - Andy Wahrenberger: Industrial Strenght NuGet](http://channel9.msdn.com/Series/mvcConf/mvcConf-2-Andy-Wahrenberger-Industrial-Strenght-NuGet)
+###[mvcConf 2 - Andy Wahrenberger: Industrial Strenght NuGet](http://channel9.msdn.com/Series/mvcConf/mvcConf-2-Andy-Wahrenberger-Industrial-Strength-NuGet)
 <iframe style="height:288px;width:512px" src="http://channel9.msdn.com/Series/mvcConf/mvcConf-2-Andy-Wahrenberger-Industrial-Strenght-NuGet/player?w=512&h=288" frameBorder="0" scrolling="no" ></iframe>
 
 ###[NDC 2011 - Damian Edwards: NuGet in a caramel coated nutshell](http://ndc2011.macsimum.no/mp4/Day3%20Friday/Track1%201020-1120.mp4)


### PR DESCRIPTION
Saw this typo Strenght -> Strength in the videos page.
