### PR TITLE
Fixed "Creating a Package" link in faq page

### DIFF
--- a/site/Docs/Start-Here/NuGet-FAQ.markdown
+++ b/site/Docs/Start-Here/NuGet-FAQ.markdown
@@ -37,7 +37,7 @@ Typically, a solution-level package installs new commands that can be called fro
 
 ## I have multiple versions of my library that target different versions of the .NET Framework. How do I build a single package that supports this?
 
-See the section titled "Supporting Multiple .NET Framework Versions and Profiles" in [Creating a Package](http://nuget.codeplex.com/wikipage?title=Creating%20a%20Package#supporting-multiple-framework-versions).
+See the section titled "Supporting Multiple .NET Framework Versions and Profiles" in [Creating a Package](http://docs.nuget.org/docs/creating-packages/creating-and-publishing-a-package#Creating_a_Package).
 
 ## How do I check the exact version of NuGet installed?
 


### PR DESCRIPTION
"Creating a Package" link in faq page had spaces in the markdown syntax
which caused the markdown itself to be output instead of an html link.
