### PR TITLE
Make prettyprint work.  Code blocks get syntax highlights.

### DIFF
--- a/site/Docs/_DocLayout.cshtml
+++ b/site/Docs/_DocLayout.cshtml
@@ -15,9 +15,12 @@
 
 <script>
     $(document).ready(function () {
-        if (!$('pre').attr('class') == 'none') {
-            $('pre').addClass('prettyprint');
-        }
+        //for each pre element that has a code element child...
+        $("pre > code").parent().each(function () {
+            if (!$(this).hasClass("prettyprint") && !$(this).hasClass("none")) {
+                $(this).addClass("prettyprint");
+            }
+        });
         prettyPrint();
     });
 </script>


### PR DESCRIPTION
The old version failed to loop over the elements.  It also used a selector that would get all pre elements instead of only those that have a code element child.  This change takes care of both of those issues.
