### PR TITLE
Wording updates, disclaimer on packages.config

### DIFF
--- a/site/Docs/Workflows/Using-NuGet-without-committing-packages.markdown
+++ b/site/Docs/Workflows/Using-NuGet-without-committing-packages.markdown
@@ -61,7 +61,7 @@ The _NuGet.config_ file contains the following XML:
 	</configuration>
 
 The `disableSourceControlIntegration` setting instructs version control systems like TFS to ignore 
-the NuGet packages folder to the pending check-ins list.
+the NuGet packages folder when determining files to check in.
 
 With this in place, any time a project is compiled, the build task will look at each project's 
 _packages.config_ file and for each package listed, ensure that the corresponding package exists within 


### PR DESCRIPTION
The intro wording was aging, referring to old workflow from a year ago or more.  Updated that, and made all the file name formatting consistent.  

I updated some text around project files and added the XML for importing targets. 

Finally, I added a warning on packages.config as a result of some problems that I've had maintaining solutions with package restore in an SVN environment.
