### PR TITLE
Added work-around language to package ignores for SVN.

### DIFF
--- a/site/Docs/Workflows/Using-NuGet-without-committing-packages.markdown
+++ b/site/Docs/Workflows/Using-NuGet-without-committing-packages.markdown
@@ -62,10 +62,18 @@ With this in place, any time a project is compiled, the build task will look at 
 In this scenario, NuGet will grab the exact version when restoring a package. It will not perform any upgrades.
 
 <p class="caution"><b>Be sure to check in your _repositories.config_ file.</b> Some version control systems, 
-such as SVN, may not allow you to exclude a path _and_ include a file, such as your _repositories.config_ in 
-the subdirectory of "Packages". You'll need to agree with your team to include the folder from the root 
-of your solution, explicitly include the _repositories.config_ file but _not_ check in any packages. Without 
-the file you may experience problems loading or building a multi-project solution with package restore enabled.</p>
+such as Subversion (a.k.a. SVN), may require additional configuration to allow you to selectively ignore an arbitrary set of files in a path, _but_ include a specific file, such as your _repositories.config_ in that path.
+<br/>
+For SVN specifically, you may use SVN:IGNORE to prevent paths with certain patterns from being committed (and making a mess in your pending changes views).
+By adding the following pattern as an SVN:IGNORE to your "packages" directory, the repositories.config will be committed, but nuget package directories will be ignored.
+<br/>
+*[0-9]*
+<br/>
+Similar ignore patterns are probably available for most source control systems.
+<br/>
+In rare cases, you'll need to agree with your team to include the folder from the root of your solution, explicitly include the _repositories.config_ file but _not_ check in any packages. Without 
+the file you may experience problems loading or building a multi-project solution with package restore enabled.
+</p>
 
 ## Mono
 On mono you can run `xbuild` on the project file or on your solution and it should successfully 


### PR DESCRIPTION
It is possible to keep SVN (and most other source control systems) happy with the packages directory, without having the friction of a bunch of pending packages blocking the view of actual changes.

This is achieved based on the assumption that all packages that are downloaded and stored in this directory follow the "[package name][version]" convention. And that NuGet versions follow semantic versioning, which always has some numbers.

I adjusted the language to reflect how to make using package restore in conjunction with SVN easier.
