### PR TITLE
fixed restore example for -source

### DIFF
--- a/site/Docs/Reference/Command-Line-Reference.markdown
+++ b/site/Docs/Reference/Command-Line-Reference.markdown
@@ -344,7 +344,7 @@ file:
     nuget restore proj1\packages.config -PackagesDirectory ..\packages
     
     # Restore packages for the solution in the current folder, specifying package sources
-    nuget restore -Source -source https://www.nuget.org/api/v2;https://www.myget.org/F/nuget
+    nuget restore -source "https://www.nuget.org/api/v2;https://www.myget.org/F/nuget"
 
 
 ##  List Command


### PR DESCRIPTION
Removed double -source from restore example and put package source into double quotes. Otherwise powershell interprets the semicolon.
