### PR TITLE
Updated docs to w.r.t. to source control integration

### DIFF
--- a/site/Docs/Reference/Package-Restore-with-Team-Build.markdown
+++ b/site/Docs/Reference/Package-Restore-with-Team-Build.markdown
@@ -62,7 +62,16 @@ The source code is under the `src` folder. Although our demo only uses a single 
 ### Ignore Files
 
 <p class="info">
-<strong>Note:</strong> There is currently a <a href="https://nuget.codeplex.com/workitem/4072">known bug in the NuGet Client</a> that causes the client to still add the <code>packages</code> folder to version control. A workaround is to disable the source control integration by placing a nuget.config file <a href="http://docs.nuget.org/docs/release-notes/nuget-2.1#Hierarchical_Nuget.config">in the root of your repostitory</a>, specifying disableSourceControlIntegration=true. For more details have a look the <a href="http://docs.nuget.org/docs/reference/nuget-config-settings">documentation on config settings</a>.
+<strong>Note:</strong> There is currently a <a href="https://nuget.codeplex.com/workitem/4072">known bug in the NuGet Client</a> that causes the client to still add the <code>packages</code> folder to version control. A workaround is to disable the source control integration. In order to do that, you'll need a <code>nuget.config</code> file in the <code>.nuget</code> folder that is parallel to your solution. If this folder doesn't exist yet, you'll need to create it. In <code>nuget.config</code>, add the following content:<br>
+
+<pre><code>&lt;configuration>
+    &lt;solution>
+        &lt;add key="disableSourceControlIntegration" value="true" />
+    &lt;/solution>
+&lt;/configuration>
+</code></pre>
+
+For more details have a look at the <a href="http://docs.nuget.org/docs/reference/nuget-config-settings">documentation on config settings</a>.
 </p>
 
 In order to communicate to the version control that we don’t intent to check-in the **packages** folders, we've also added ignore files for both git (`.gitignore`) as well as TF version control (`.tfignore`). These files describes patterns of files you don't want to check-in.


### PR DESCRIPTION
This fixes the info box to call out that you can only disable the source control integration by placing the `nuget.config` in the `.nuget` folder that is parallel to the solution file.
