### PR TITLE
Adds missing "s" in example files Xml for NuSpec-Reference

### DIFF
--- a/site/Docs/Reference/Nuspec-Reference.markdown
+++ b/site/Docs/Reference/Nuspec-Reference.markdown
@@ -180,7 +180,7 @@ For instance:
 
     <files>
       <file src="bin\$configuration$\$id$.pdb" target="lib\net40\" />
-    </file>
+    </files>
 
 Assuming you are building the project that produces an assembly called Foo in release mode this will produce the following transformed xml:
     


### PR DESCRIPTION
The closing tag of the files example was missing an "s"
