### PR TITLE
Update the definition of "solution-level package"

### DIFF
--- a/site/Docs/Creating-Packages/Creating-and-Publishing-a-Package.markdown
+++ b/site/Docs/Creating-Packages/Creating-and-Publishing-a-Package.markdown
@@ -207,15 +207,15 @@ To create your package.
 ### Creating a solution-level package
 
 A solution-level package is one that installs a tool or additional commands
-for the Package Manager console, but does not add references or content
-to any projects in your solution. For example, the
+for the Package Manager console, but does not add references, content, or
+build customizations to any projects in your solution. For example, the
 [psake](http://nuget.org/packages/psake) package installs Powershell scripts
 you can use to automate your build process.
 
 A package is considered a solution-level package if it does not contain
-any files in its __lib__ or __content__ directories.  If the package has
-dependencies, they also must not have files in their __lib__ or __content__
-directories.
+any files in its __lib__, __content__, or __build__ directories.  If the package
+has dependencies, they also must not have files in their __lib__, __content__,
+or __build__ directories.
 
 When a solution-level package is installed, it is tracked in a packages.config
 file in the .nuget directory, rather than in a packages.config file in a


### PR DESCRIPTION
Update the definition of "solution-level package" to reflect the fact that files in the build directory will prevent a package from being treated as one.
