### PR TITLE
don't need to keep repositories.config in DVCS

### DIFF
--- a/site/Docs/Workflows/Using-NuGet-without-committing-packages.markdown
+++ b/site/Docs/Workflows/Using-NuGet-without-committing-packages.markdown
@@ -60,23 +60,6 @@ With this in place, any time a project is compiled, the build task will look at 
 
 In this scenario, NuGet will grab the exact version when restoring a package. It will not perform any upgrades.
 
-<p class="caution"><b>Be sure to check in your <em>repositories.config</em> file.</b> Some version control systems, 
-such as Subversion (a.k.a. SVN), may require additional configuration to allow you to selectively ignore an arbitrary set of files in a path, <em>but</em> include a specific file, such as your <em>repositories.config</em> in that path.
-<br/>
-For SVN specifically, you may use SVN:IGNORE to prevent paths with certain patterns from being committed (and making a mess in your pending changes views).
-By adding the following patterns as an SVN:IGNORE to your "packages" directory, the repositories.config will be committed, but nuget package directories will be ignored.
-<br/>
-<pre><code>
-*[!c][!o][!n][!f][!i][!g]
-*.config?*
-</code></pre>
-<br/>
-Similar ignore patterns are probably available for most source control systems.
-<br/>
-In rare cases, you'll need to agree with your team to include the folder from the root of your solution, explicitly include the _repositories.config_ file but _not_ check in any packages. Without 
-the file you may experience problems loading or building a multi-project solution with package restore enabled.
-</p>
-
 ## Mono
 On mono you can run `xbuild` on the project file or on your solution and it should successfully 
 restore packages for any project that has package restore enabled.


### PR DESCRIPTION
As mentioned in https://github.com/NuGet/NuGetDocs/pull/262#issuecomment-56222507 "it's actually okay to omit the `repositories.config` from source control, as NuGet will re-generate it when you open the solution again." This however conflicts with information mentioned at https://stackoverflow.com/questions/7286261/nuget-repositories-config, https://stackoverflow.com/questions/7015149/multiperson-team-using-nuget-and-source-control, & https://github.com/github/gitignore/blob/master/VisualStudio.gitignore#L140. I believe those are all based on a dependency on `repositories.config` that existed previously but that new versions of NuGet & VS better generate it or work around not having it when needed.

Fixes https://github.com/NuGet/NuGetDocs/issues/175 & https://github.com/NuGet/NuGetDocs/pull/92#issuecomment-48626010.
