### PR TITLE
refer to Solution Explorer as from Visual Studio

### DIFF
--- a/site/Docs/Start-Here/Managing-NuGet-Packages-Using-The-Dialog.markdown
+++ b/site/Docs/Start-Here/Managing-NuGet-Packages-Using-The-Dialog.markdown
@@ -10,7 +10,7 @@ on [Managing Packages for the Solution](#Managing_Packages_for_the_Solution).
 
 ## Finding a Package
 
-In **Solution Explorer**, right-click the **References** node and click **Manage NuGet Packages...**. 
+In Visual Studio **Solution Explorer**, right-click the **References** node and click **Manage NuGet Packages...**. 
 (Note, in a Website project, right click on the **Bin** node.)
 
 ![Manage NuGet Packages menu option](images/manage-nuget-packages-menu-option.png)


### PR DESCRIPTION
I found these instructions quite confusing. Specifically, I was stumped when I read the instructions which mention Solution Explorer (I eventually discovered it was a screenshot from Visual Studio). I spent an hour looking for the NuGet package that I had installed and from where I should the run the package; I had no idea whether the screenshot had come from a separate NuGet executable or what. Not all readers come from other instructions or pages referencing Visual Studio. I finally found out that that screenshot comes from the Visual Studio Tools menu. Not everyone ends up at the page from a link or some other source that lets us know that once installed, it is accessible from VS. HTH
