### PR TITLE
Directory path should have double quotes

### DIFF
--- a/site/Docs/Reference/Command-Line-Reference.markdown
+++ b/site/Docs/Reference/Command-Line-Reference.markdown
@@ -204,7 +204,7 @@ Specify the id and optionally the version of the package to install. If a path t
     
     nuget install packages.config
     
-    nuget install ninject -o c:\foo
+    nuget install ninject -o c:\\folder\\name
 
 
 


### PR DESCRIPTION
Directory path should be escaped - double slashes, otherwise it installs in your current directory. I checked on 2.8.5 version. If I'm right, I'll update the rest of the paths accordingly
