### PR TITLE
Fixed broken link extend nuget blog post

### DIFF
--- a/site/Docs/Start-Here/NuGet-FAQ.markdown
+++ b/site/Docs/Start-Here/NuGet-FAQ.markdown
@@ -91,7 +91,7 @@ Once you have the command-line, use "NuGet.exe Update" to self update the exe to
 **Is it possible to extend NuGet commandline?**
 
 Yes, it is possible to add custom commands to NuGet.exe.
-Check out [this post](http://devlicious.com/blogs/rob_reynolds/archive/2011/07/15/extend-nuget-command-line.aspx) by Rob Reynolds for a quick walkthrough.
+Check out [this post](http://devlicio.us/blogs/rob_reynolds/archive/2011/07/15/extend-nuget-command-line.aspx) by Rob Reynolds for a quick walkthrough.
 
 
 ## NuGet Package Manager Console


### PR DESCRIPTION
The link to Rob Reynolds 'extend nuget command line' is broken and should be changed to http://devlicio.us/blogs/rob_reynolds/archive/2011/07/15/extend-nuget-command-line.aspx instead of http://devlicious.com/....