### PR TITLE
Updated description for Octopus Deploy

### DIFF
--- a/site/Docs/Reference/Ecosystem.markdown
+++ b/site/Docs/Reference/Ecosystem.markdown
@@ -191,7 +191,7 @@ Provides:
   * Python
 
 ## OctopusDeploy
-[OctopusDeploy](http://octopusdeploy.com/) is a convention-based automated deployment solution using NuGet as a protocol. You can use the Community edition for free (limited to 1 project) or [buy](http://octopusdeploy.com/purchase) one of the paying editions.
+[OctopusDeploy](http://octopusdeploy.com/) is a convention-based automated deployment solution using NuGet as a protocol. You can use the Community edition for free (limited to 5 projects) or [buy](http://octopusdeploy.com/purchase) one of the paying editions.
 
 * Documentation: [http://octopusdeploy.com/documentation](http://octopusdeploy.com/documentation)
 * Blog: [http://octopusdeploy.com/blog](http://octopusdeploy.com/blog)


### PR DESCRIPTION
The community edition of Octopus Deploy allows you to deploy 5 projects (not 1 project as stated on this page earlier), up to 10 tentacles and is limited to 5 users. See https://octopusdeploy.com/purchase for details.