### PR TITLE
Corrected spelling of steep

### DIFF
--- a/site/Docs/Reference/Ecosystem.markdown
+++ b/site/Docs/Reference/Ecosystem.markdown
@@ -354,7 +354,7 @@ There are quite a few other tools and utilities building further on top of NuGet
 * [DefinitelyTyped](http://definitelytyped.org/) ([Automatic](https://github.com/DefinitelyTyped/NugetAutomation/) TypeScript Type [Definitions published to NuGet](http://www.nuget.org/packages?q=DefinitelyTyped))
 
 ## Training Materials and References
-Using a new tool or technology usually comes with a learning curve. Luckily for you, NuGet has no steap learning curve it all! In fact, anyone can [get started consuming packages in no time](http://www.youtube.com/watch?feature=player_embedded&v=PboPfoptU2c). Authoring packages however, and especially authoring good packages, as well as embracing NuGet in your automated build and deployment processes requires some research in order to get things right.
+Using a new tool or technology usually comes with a learning curve. Luckily for you, NuGet has no steep learning curve it all! In fact, anyone can [get started consuming packages in no time](http://www.youtube.com/watch?feature=player_embedded&v=PboPfoptU2c). Authoring packages however, and especially authoring good packages, as well as embracing NuGet in your automated build and deployment processes requires some research in order to get things right.
 
 The following pointers should help you get the maximum out of NuGet:
 


### PR DESCRIPTION
steep was wrongly spelled as steap