### PR TITLE
Fixed edit link

### DIFF
--- a/NuGet.Docs/_Layout.cshtml
+++ b/NuGet.Docs/_Layout.cshtml
@@ -74,7 +74,7 @@
         {
             <p>
                 View or edit this page's source on GitHub:
-                <a href="https://github.com/NuGet/NuGetDocs/tree/master/NuGet.Docs/@HttpUtility.UrlPathEncode(Page.Source)" target="edit">https://github.com/NuGet/NuGetDocs/tree/master/site/@HttpUtility.UrlPathEncode(Page.Source)</a>
+                <a href="https://github.com/NuGet/NuGetDocs/tree/master/NuGet.Docs/@HttpUtility.UrlPathEncode(Page.Source)" target="edit">https://github.com/NuGet/NuGetDocs/tree/master/NuGet.Docs/@HttpUtility.UrlPathEncode(Page.Source)</a>
             </p>
         }
         else

--- a/NuGet.Docs/_Layout.cshtml
+++ b/NuGet.Docs/_Layout.cshtml
@@ -74,7 +74,7 @@
         {
             <p>
                 View or edit this page's source on GitHub:
-                <a href="https://github.com/NuGet/NuGetDocs/tree/master/site/@HttpUtility.UrlPathEncode(Page.Source)" target="edit">https://github.com/NuGet/NuGetDocs/tree/master/site/@HttpUtility.UrlPathEncode(Page.Source)</a>
+                <a href="https://github.com/NuGet/NuGetDocs/tree/master/NuGet.Docs/@HttpUtility.UrlPathEncode(Page.Source)" target="edit">https://github.com/NuGet/NuGetDocs/tree/master/site/@HttpUtility.UrlPathEncode(Page.Source)</a>
             </p>
         }
         else


### PR DESCRIPTION
The edit link on an document page was still to the `site` folder instead of `NuGet.Docs`