### PR TITLE
Update link to developmentDependency change notes.

### DIFF
--- a/NuGet.Docs/Create/Nuspec-Reference.md
+++ b/NuGet.Docs/Create/Nuspec-Reference.md
@@ -129,7 +129,7 @@ package is built (but without the element that lists files if that element was i
     </tr>
     <tr>
         <td>developmentDependency</td>
-        <td><a href="/Release-Notes/NuGet-2.8">v2.8</a> A Boolean value that specifies whether the package will be marked as a <a href="../Release-Notes/NuGet-2.7#Development-Only-Dependencies">development-only dependency</a> in the packages.config. This will cause the package to be excluded from the dependency list when the referencing project itself is later packaged.</td>
+        <td><a href="/Release-Notes/NuGet-2.8">v2.8</a> A Boolean value that specifies whether the package will be marked as a <a href="../Release-Notes/NuGet-2.7#development-only-dependencies">development-only dependency</a> in the packages.config. This will cause the package to be excluded from the dependency list when the referencing project itself is later packaged.</td>
     </tr>
 </tbody>
 </table>


### PR DESCRIPTION
The links are case sensitive so currently the development-only dependency link just points you to the 2.7 release notes instead of the specific section associated with the change.  This updates to use the correctly cased link.