### PR TITLE
Clarify which version this Package Restore setting is for

### DIFF
--- a/NuGet.Docs/Consume/NuGet-Config-Settings.md
+++ b/NuGet.Docs/Consume/NuGet-Config-Settings.md
@@ -32,7 +32,7 @@ Below is the summary of the NuGet config keys and their usage.
 
 	</td>
 	<td>
-	Allows you to restore missing packages from the NuGet source during build.<br/>
+	<strong> Used for Pre-2.7 Nuget Package Restore only.</strong><br/>Allows you to restore missing packages from the NuGet source during build.<br/>
 	The environment variable "EnableNuGetPackageRestore" with a value of "true" can be used in place of the "enabled" key in the config file.<br/>
 	More details <a href="Package-Restore"> here.</a>
 


### PR DESCRIPTION
In Version 2.7, Nuget offered a 'new' way of doing package restore that doesn't require what Pre-2.7 requires.  This is evident after a long read of the changes, but not evident here; which could cause confusion and unexpected behavior.  This edit simply clarifies what version this setting works for.