### PR TITLE
Make images reponsive

### DIFF
--- a/NuGet.Docs/css/nuget.docs.css
+++ b/NuGet.Docs/css/nuget.docs.css
@@ -244,6 +244,11 @@ body {
     width: 1370px;
 }
 
+img {
+    max-width: 100%;
+    height: auto;
+}
+
 @media all AND (min-width: 1280px) AND (max-width: 1599px) {
     body {
         width: 1200px;


### PR DESCRIPTION
This changes makes sure that image files are not overflowing the viewport when using a small screen device, but adjusted its width with the parent container