### PR TITLE
Explain that vs templates should omit nuget refs

### DIFF
--- a/NuGet.Docs/Create/Packages-in-Visual-Studio-Templates.md
+++ b/NuGet.Docs/Create/Packages-in-Visual-Studio-Templates.md
@@ -23,6 +23,11 @@ these links to find more information on how to create templates [directly
 using Visual Studio](http://msdn.microsoft.com/en-us/library/s365byhx.aspx)
 or [using the Visual Studio SDK](http://msdn.microsoft.com/en-us/library/ff527340.aspx).
 
+You should author your template such that it does _not_ include the `packages.config`
+file or any references or content that installing the NuGet package(s) would add to
+the project. In the next section, you'll use a custom wizard that will add those
+files and references to the project as part of template expansion.
+
 ## Adding packages to a template
 
 Preinstalled packages work using [template wizards](http://msdn.microsoft.com/en-us/library/ms185301.aspx).


### PR DESCRIPTION
Explains more clearly that the project or item template authored into the VSIX should itself not include the artifacts that NuGet would add to a project. This seems non-obvious to folks since when they're reading these docs, they already have a working project template and they want to NuGet-tize it. So the first step is to actually _remove_ all the references from their template that they need, since NuGet will be responsible to add them right back. 
This commit adds the necessary explanatory text.