### PR TITLE
Minor Typo

### DIFF
--- a/NuGet.Docs/Create/Default.cshtml
+++ b/NuGet.Docs/Create/Default.cshtml
@@ -24,7 +24,7 @@
             <h1>Symbol, Localized and Transform Packages</h1>
         </header>
         <p>
-            In this section, learn about creating symbol, localized or config file and source code transformation packages and specifying dependenvy versions for packages.
+            In this section, learn about creating symbol, localized or config file and source code transformation packages and specifying dependency versions for packages.
         </p>
         <footer>
             <a href="/Create/Creating-and-Publishing-a-Symbol-Package" title="Creating and Publishing a Symbol Package">Symbol Packages</a>


### PR DESCRIPTION
Fixed a minor typo under the heading "Symbol, Localized and Transform Packages". The descriptive sentence had
  "... dependenvy ..."
It should be
  "... dependency ..."