### PR TITLE
Fixed how-to enable nuget.exe mirror command

### DIFF
--- a/NuGet.Docs/Consume/Command-Line-Reference.md
+++ b/NuGet.Docs/Consume/Command-Line-Reference.md
@@ -748,8 +748,7 @@ Gets or sets NuGet config values.
 
 Mirrors a package and its dependencies from the specified source repositories to the target repository.
 
-Note: to enable this command, navigate to [http://build.nuget.org/](http://build.nuget.org/) (there's a Guest log in option),
-copy NuGet.ServerExtensions.dll from Artifacts,CommandLine.ServerExtensions to your local disk in the same directory as NuGet.exe.
+Note: to enable this command, navigate to [https://nuget.codeplex.com/releases](https://nuget.codeplex.com/releases), select newest stable release, download NuGet.ServerExtensions.dll and Nuget-Signed.exe to your local disk and rename the Nuget-Signed.Exe to NuGet.exe.
 
 ### Mirror Command Usage
     nuget mirror packageId|pathToPackagesConfig listUrlTarget publishUrlTarget [options]


### PR DESCRIPTION
The instructions available now point to TeamCity build server, where, currently at least, Guests do not have access to any projects.

I found that the NuGet.ServerExtensions.dll is available on the CodePlex site for Nuget2. Also it appears that the dll is build against signed NuGet.exe (discussed in #559), so it is also needed to download the NuGet-Signed.exe.