### PR TITLE
Rewrite settings doc page

### DIFF
--- a/NuGet.Docs/Consume/NuGet-Config-Settings.md
+++ b/NuGet.Docs/Consume/NuGet-Config-Settings.md
@@ -87,7 +87,7 @@ The values can be added to the config file directly or using the package manager
 **key**: disableSourceControlIntegration
 
 Allows you to disable source control integration for the "Packages" folder.
-This key works at the solution level and hence need to be added to the NuGet.config file present in the `$(SolutionDir)\.nuget directory`.
+This key works at the solution level and hence need to be added to the NuGet.config file present in the `$(SolutionDir)\.nuget` directory.
 Enabling package restore from VS would add the `.nuget\nuget.config` file automatically.
 More details [here](../Docs/Workflows/Using-NuGet-without-committing-packages).
 

--- a/NuGet.Docs/Consume/NuGet-Config-Settings.md
+++ b/NuGet.Docs/Consume/NuGet-Config-Settings.md
@@ -31,7 +31,9 @@ Or for relative path (note the forward slashes for relative path), note: relativ
 **section**: config  
 **key**: dependencyVersion
 
-Defines what the default DependencyVersion value is, if the `-DependencyVersion` switch is not specified in an invocation of `install-package`. This value will also be respected by the NuGet Package Manager Dialog for any install package operations in projects with a packages.config file. To set this value, add the attribute below to your nuget.config file:
+Defines what the default DependencyVersion value is, if the `-DependencyVersion` switch is not specified in an invocation of `install-package`.
+This value will also be respected by the NuGet Package Manager Dialog for any install package operations in projects with a packages.config file.
+To set this value, add the attribute below to your nuget.config file:
 
     <config>
       <add key="dependencyVersion" value="Highest" />

--- a/NuGet.Docs/Consume/NuGet-Config-Settings.md
+++ b/NuGet.Docs/Consume/NuGet-Config-Settings.md
@@ -22,19 +22,9 @@ Or for relative path (note the forward slashes for relative path), note: relativ
 <strong>Note</strong><br/>Relative path is only relative to the solution folder.
 </p>
 
-	<pre><code>
-    &lt;config&gt;
-     &lt;add key="repositoryPath" value="../relativepath" /&gt;
-    &lt;/config&gt;
-	</pre></code>
-
     <config>
       <add key="repositoryPath" value="../relativepath" />
     </config>
-
-<p class="info">
-<strong>Note</strong><br />Versions 3.0 - 3.2 has a <a href="https://github.com/NuGet/Home/issues/755">bug</a> where the path needs a backward slash
-</p>
    
 ## Dependency version
 

--- a/NuGet.Docs/Consume/NuGet-Config-Settings.md
+++ b/NuGet.Docs/Consume/NuGet-Config-Settings.md
@@ -63,8 +63,7 @@ More details [here](Package-Restore).
 
 ## Package sources
 
-**section**: packageSources  
-**keys**: disabledPackageSources and activePackageSource
+**sections**: packageSources, disabledPackageSources and activePackageSource  
 
 Allows you to specify the list of sources to be used while looking for packages.
 

--- a/NuGet.Docs/Consume/NuGet-Config-Settings.md
+++ b/NuGet.Docs/Consume/NuGet-Config-Settings.md
@@ -1,27 +1,22 @@
 # NuGet Configuration Settings
+
 There are a bunch of NuGet configuration values which can be set via the nuget.config file.
 Below is the summary of the NuGet config keys and their usage, note the keys are case sensitive.
 
-<table class="reference">
-<tbody>
-    <tr>
-        <th>Settings  </th> <th>Key Name</th> <th>Description</th>
-    </tr>
-    <tr>
-    <td> Repository path </td>
-    <td>"repositoryPath" </td>
-    <td>
-       Allows  you to install the NuGet packages in the specified folder, instead of the default "$(Solutiondir)\Packages" folder. <br/>
-       This key can be added to the NuGet.config file manually or using the <a href="Command-Line-Reference#Config Command"> NuGet.exe Config -Set command.  </a>  <br/>
-       More details <a href="../Release-Notes/NuGet-2.1#Specify-%e2%80%98packages%e2%80%99-Folder-Location">here.</a>
+## Repository path
 
-	<pre><code>
-    &lt;config&gt;
-     &lt;add key="repositoryPath" value="C:\Temp" /&gt;
-    &lt;/config&gt;
-	</pre></code>
-	
-OR for relative path (note the forward slashes for relative path)
+**section**: config  
+**key**: repositoryPath
+
+Allows  you to install the NuGet packages in the specified folder, instead of the default `"$(Solutiondir)\Packages"` folder.
+This key can be added to the NuGet.config file manually or using the [NuGet.exe Config -Set command](Command-Line-Reference#config-command).
+More details [here](../Release-Notes/NuGet-2.1#specify-%E2%80%98packages%E2%80%99-folder-location).
+
+    <config>
+      <add key="repositoryPath" value="C:\Temp" />
+    </config>
+
+Or for relative path (note the forward slashes for relative path), note: relative path is only relative to the solution folder.
 
 <p class="info">
 <strong>Note</strong><br/>Relative path is only relative to the solution folder.
@@ -33,171 +28,142 @@ OR for relative path (note the forward slashes for relative path)
     &lt;/config&gt;
 	</pre></code>
 
+    <config>
+      <add key="repositoryPath" value="../relativepath" />
+    </config>
+
 <p class="info">
 <strong>Note</strong><br />Versions 3.0 - 3.2 has a <a href="https://github.com/NuGet/Home/issues/755">bug</a> where the path needs a backward slash
 </p>
    
-    </td>
-    </tr>
-    <tr>
-    <td> Dependency Version </td>
-    <td>"dependencyVersion" </td>
-    <td>
-       
-Defines what the default DependencyVersion value is, if the -DependencyVersion switch is not specified in an invocation of install-package. This value will also be respected by the NuGet Package Manager Dialog for any install package operations in projects with a packages.config file. To set this value, add the attribute below to your nuget.config file:
+## Dependency version
 
-	<pre><code>
-    &lt;config&gt;
-     &lt;add key="dependencyVersion" value="Highest" /&gt;
-    &lt;/config&gt;
-	</pre></code>
-	
-	Allowed values for dependencyVersion are: Lowest, HighestPatch, HighestMinor, Highest
-    <p>
-    Information about semantic versioning and what these values apply to can be found in <a href="http://docs.nuget.org/Create/Versioning#really-brief-introduction-to-semver">Versioning</a>.
-    </p>
+**section**: config  
+**key**: dependencyVersion
 
-    </td>
-    </tr>
-	<tr>
-	<td> Package Restore
-	</td>
-	<td> "enabled" and "automatic" under the section "packageRestore"
+Defines what the default DependencyVersion value is, if the `-DependencyVersion` switch is not specified in an invocation of `install-package`. This value will also be respected by the NuGet Package Manager Dialog for any install package operations in projects with a packages.config file. To set this value, add the attribute below to your nuget.config file:
 
-	</td>
-	<td>
-	<strong> Used for Pre-2.7 Nuget Package Restore only.</strong><br/>Allows you to restore missing packages from the NuGet source during build.<br/>
-	The environment variable "EnableNuGetPackageRestore" with a value of "true" can be used in place of the "enabled" key in the config file.<br/>
-	More details <a href="Package-Restore"> here.</a>
+    <config>
+      <add key="dependencyVersion" value="Highest" />
+    </config>
 
-	<pre><code>
-	&lt;packageRestore&gt;
-		&lt;!-- Allow NuGet to download missing packages --&gt;
-		&lt;add key="enabled" value="True" /&gt;
+Allowed values for dependencyVersion are: Lowest, HighestPatch, HighestMinor, Highest
 
-		&lt;!-- Automatically check for missing packages during build in Visual Studio --&gt;
-		&lt;add key="automatic" value="True" /&gt;
-	&lt;/packageRestore&gt;
-	</pre></code>
+Information about semantic versioning and what these values apply to can be found in [Versioning](../Create/Versioning#really-brief-introduction-to-semver).
 
-	</td>	  
-	</tr>
-	<tr>
-	<td> Package sources
-	</td> 
-	<td> "activePackageSource" , "packageSources" , "disabledPackageSources"
-	</td>
-	<td>
-	   Allows you to specify the list of sources to be used while looking for packages. <br/>
-	   
-	- "PackageSources" section has the list of package sources. <br/> 
-	- "DisabledPackageSources" has the list of sources which are currently disabled.  <br/>
-	- "ActivePackageSource" points to the currently active source. Speciying "(Aggregate source)" as the source value would imply that all the current package sources except for the disabled ones are active.<br/></br> </br>
+## Package Restore
 
-		The values can be added to the config file directly or using the package manager settings UI ( which would in turn update the NuGet.config file) or using the <a href="Command-Line-Reference#Sources-Command">NuGet.exe Sources command.</a>
+**section**: packageRestore  
+**keys**: enabled and automatic
 
-	<pre><code>
-	&lt;packageSources&gt;
-		&lt;add key="NuGet official package source" value="https://nuget.org/api/v2/" /&gt;
-		&lt;add key="TestSource" value="C:\Temp" /&gt;
-	&lt;/packageSources&gt;
-	&lt;disabledPackageSources /&gt;
-	&lt;activePackageSource&gt;
-		&lt;add key="All" value="(Aggregate source)"  /&gt;
-	&lt;/activePackageSource&gt;
-	</pre></code>
+**Used for Pre-2.7 Nuget Package Restore only.**
 
-	</td>
-	</tr>
-	<tr>
-	<td> Source control integration
+Allows you to restore missing packages from the NuGet source during build.
+The environment variable `EnableNuGetPackageRestore` with a value of `true` can be used in place of the `enabled` key in the config file.
+More details [here](Package-Restore).
 
-	</td>
-	<td> "disableSourceControlIntegration" under section "solution"
-	</td>
-    <td>
-	Allows you to disable source control integration for the "Packages" folder. This key works at the solution level and hence need to be added to the NuGet.config file present in the "$(SolutionDir)\.nuget directory". Enabling package restore from VS would add the .nuget\nuget.config file automatically. More details <a href="..\Workflows\Using-NuGet-without-committing-packages"> here.</a>
-    <br/>
+    <packageRestore>
+      <!-- Allow NuGet to download missing packages -->
+      <add key="enabled" value="True" />
+      <!-- Automatically check for missing packages during build in Visual Studio -->
+      <add key="automatic" value="True" />
+    </packageRestore>
 
-	The default value for this key is true.
-	<pre><code>
-	&lt;solution&gt;
-		&lt;add key="disableSourceControlIntegration" value="true" /&gt;
-	&lt;/solution&gt;
-	</code></pre>
+## Package sources
 
-	</td>
-	</tr>
-	<tr>
-	<td>  Proxy settings
-	</td>
-	<td> "http_proxy" ,  "http_proxy.user", "http_proxy.password" 
+**section**: packageSources  
+**keys**: disabledPackageSources and activePackageSource
 
-	</td>
-	<td>
-	Allows you to set the proxy settings to be used while connecting to your NuGet feed.
-	More details <a href="http://skolima.blogspot.com/2012/07/nuget-proxy-settings.html">here.</a>
-	<br/>
+Allows you to specify the list of sources to be used while looking for packages.
 
-	This key can be added using <a href="Command-Line-Reference#Config Command">NuGet.exe Config -Set command.</a> <br/><br/>It can also be set via environment variable "http_proxy". While setting env variable, the value should  be specified in the format 'http://[username]:[password]@proxy.com'.
-	
-	<p class="info">
-<strong>Note</strong><br />The "http_proxy.password" key value is encrypted before storing in the nuget.config file. Hence it can not be added manually by directly updating the config file.</p>
+* `packageSources` section has the list of package sources.
+* `disabledPackageSources` has the list of sources which are currently disabled.
+* `activePackageSource` points to the currently active source. Specifying `(Aggregate source)` as the source value would imply that all the current package sources except for the disabled ones are active.
 
-	</td>
-	</tr>
-	<tr>
-	<td> Credentials for package source
-	</td>
-	<td> "Username",  "Password" and "ClearTextPassword" under section "packageSourceCredentials" 
-	</td>
-	<td>
-	Allows you to set the credentials to access the given package source. <br/>
-	This key has to be set using the <a href="Command-Line-Reference#Sources-Command">NuGet.exe Sources command.</a> <br/>
-	The default behavior is to store the password encrypted in the config file. <br/> <br/>
+The values can be added to the config file directly or using the package manager settings UI (which would in turn update the NuGet.config file) or using the [NuGet.exe Sources command](Command-Line-Reference#sources-command).
 
-		<i>NuGet.exe  Sources  Add  -Name  &lt;feedName&gt; -Source &lt;pathToPackageSource&gt; -UserName  xxx   -Password &lt;secret&gt;  </i><br/>
-		<i>NuGet.exe  Sources  Update  -Name  &lt;feedName&gt; -Source &lt;pathToPackageSource&gt; -UserName  xxx   -Password &lt;secret&gt; </i><br/><br/>
+    <packageSources>
+      <add key="NuGet official package source" value="https://nuget.org/api/v2/" />
+      <add key="TestSource" value="C:\Temp" />
+    </packageSources>
+    <disabledPackageSources />
+    <activePackageSource>
+      <add key="All" value="(Aggregate source)" />
+    </activePackageSource>
 
-	This results in something similar to this:<br/>
-	<pre><code>
-		&lt;packageSourceCredentials&gt;
-			&lt;feedName&gt;
-				&lt;add key="Username" value="xxx" /&gt;
-				&lt;add key="Password" value="...encrypted..." /&gt;
-			&lt;/feedName&gt;
-		&lt;/packageSourceCredentials&gt;
-	</code></pre>
+## Source control integration
 
-	If you want to share the credentials with others then you might want to use the -StorePasswordInClearText option to disable password encryption.<br/>
-	Using this option allows you to store the password in clear text, for instance in your solution-local nuget.config using the new <a href="Command-Line-Reference">-Config option</a>, and commit it to your VCS.<br/><br/>
+**section**: solution  
+**key**: disableSourceControlIntegration
 
-		<i>NuGet.exe  Sources  Add  -Name  &lt;feedName&gt; -Source &lt;pathToPackageSource&gt; -UserName  xxx  -Password  &lt;secret&gt;  -StorePasswordInClearText -Config &lt;path to nuget.config&gt;</i><br/>
-		<i>NuGet.exe  Sources  Update  -Name  &lt;feedName&gt; -Source &lt;pathToPackageSource&gt; -UserName  xxx  -Password &lt;secret&gt; <i>-StorePasswordInClearText</i> -Config &lt;path to nuget.config&gt;</i><br/><br/>
+Allows you to disable source control integration for the "Packages" folder.
+This key works at the solution level and hence need to be added to the NuGet.config file present in the `$(SolutionDir)\.nuget directory`.
+Enabling package restore from VS would add the `.nuget\nuget.config` file automatically.
+More details [here](../Docs/Workflows/Using-NuGet-without-committing-packages).
 
-	This results in something more readable (or even manually configurable):<br/>
-	<pre><code>
-		&lt;packageSourceCredentials&gt;
-			&lt;feedName&gt;
-				&lt;add key="Username" value="xxx" /&gt;
-				&lt;add key="ClearTextPassword" value="secret" /&gt;
-			&lt;/feedName&gt;
-		&lt;/packageSourceCredentials&gt;
-	</code></pre>
-	</td>
-	</tr>
-	<tr>
-	<td> API Key to access package source
+The default value for this key is true.
 
-	</td>
-	<td>
-	</td>
-	<td>
-	Allows you to set the API Key corresponding to a specific package source.<br/>
+    <solution>
+      <add key="disableSourceControlIntegration" value="true" />
+    </solution>
 
-	This key  has to be set via <a href=".\Command-Line-Reference#Setapikey-Command">NuGet -SetApiKey. </a>
-	</td>
-	</tr>
+## Proxy settings
 
-   </tbody>
-   </table>
+**section**: config  
+**keys**: http_proxy, http_proxy.user and http_proxy.password
+
+Allows you to set the proxy settings to be used while connecting to your NuGet feed.
+More details [here](http://skolima.blogspot.com/2012/07/nuget-proxy-settings.html).
+
+This key can be added using [NuGet.exe Config -Set command](Command-Line-Reference#config-command).
+
+It can also be set via environment variable `http_proxy`.
+While setting env variable, the value should be specified in the format `http://[username]:[password]@proxy.com`.
+
+<p class="info">
+<strong>Note</strong><br />The "http_proxy.password" key value is encrypted before storing in the nuget.config file.
+Hence it can not be added manually by directly updating the config file.
+</p>
+
+## Credentials for package source
+
+**section**: packageSourceCredentials  
+**keys**: Username, Password and ClearTextPassword
+
+Allows you to set the credentials to access the given package source.
+
+This key has to be set using the [NuGet.exe Sources command](Command-Line-Reference#sources-command).
+The default behavior is to store the password encrypted in the config file.
+
+    NuGet.exe Sources Add -Name <feedName> -Source <pathToPackageSource> -UserName xxx -Password <secret>
+    NuGet.exe Sources Update -Name <feedName> -Source <pathToPackageSource> -UserName xxx -Password <secret> 
+
+This results in something similar to this:
+
+    <packageSourceCredentials>
+      <feedName>
+        <add key="Username" value="xxx" />
+        <add key="Password" value="...encrypted..." />
+      </feedName>
+    </packageSourceCredentials>
+
+If you want to share the credentials with others then you might want to use the -StorePasswordInClearText option to disable password encryption.
+Using this option allows you to store the password in clear text, for instance in your solution-local nuget.config using the new [-Config option](Command-Line-Reference#config-command), and commit it to your VCS.
+
+    NuGet.exe Sources Add -Name <feedName> -Source <pathToPackageSource> -UserName xxx -Password <secret> -StorePasswordInClearText -Config <path to nuget.config>
+    NuGet.exe Sources Update -Name <feedName> -Source <pathToPackageSource> -UserName xxx -Password <secret> -StorePasswordInClearText -Config <path to nuget.config>
+
+This results in something more readable (or even manually configurable):
+
+    <packageSourceCredentials>
+      <feedName>
+        <add key="Username" value="xxx" />
+        <add key="ClearTextPassword" value="secret" />
+      </feedName>
+    </packageSourceCredentials>
+
+## API Key to access package source
+
+Allows you to set the API Key corresponding to a specific package source.
+
+This key has to be set via [NuGet -SetApiKey](Command-Line-Reference#setapikey-command).


### PR DESCRIPTION
Replace the table layout with heading and paragraphs
Clarify sections and keys
Convert html to markdown syntax

I am planning to remove the [NuGet Configuration Settings](http://docs.nuget.org/consume/nuget-config-file#nuget-configuration-settings) in [http://docs.nuget.org/consume/nuget-config-file]() as it seems to be a duplicate of this page.

We could also remove this page and enhance the nuget-config-file instead, but for compatibility reasons I think removing the page is too dangerous.