### PR TITLE
Updated URLs to use the new SymbolSource service

### DIFF
--- a/NuGet.Docs/Create/Creating-and-Publishing-a-Symbol-Package.md
+++ b/NuGet.Docs/Create/Creating-and-Publishing-a-Symbol-Package.md
@@ -10,7 +10,7 @@ files on-demand from Visual Studio. This is a built-in feature of the IDE, that 
 .NET Framework code using [Microsoft Reference Source](http://referencesource.microsoft.com/) servers.
 It is only required to add a new symbol source in the debugger configuration (see [here](http://www.symbolsource.org/Public/Home/VisualStudio) for detailed instructions):
 
-	http://srv.symbolsource.org/pdb/Public
+	https://nuget.smbsrc.net/
 
 ## Creating a Symbol Package
 
@@ -105,7 +105,7 @@ You can push a symbol package separately, which will automatically choose [Symbo
 It is possible to override the symbol repository or to push a symbol package that doesn't follow the naming convention 
 by using the `-Source` option:
 
- 	NuGet Push MyPackage.symbols.nupkg -Source http://nuget.gw.symbolsource.org/Public/NuGet
+ 	NuGet Push MyPackage.symbols.nupkg -Source https://nuget.smbsrc.net/
 
 You can also push both packages to both repositories at the same time:
 


### PR DESCRIPTION
As we've set up our new production symbol repository, I am proposing a change to the docs to reflect that. I will submit an issue to also update the hardcoded nuget.exe push URL.

Please note that our docs are not yet updated on the SymbolSource.org site, but we'd like all users to benefit from the faster and more stable engine as soon as possible.