### PR TITLE
Fix mispelling in project.json supports field

### DIFF
--- a/NuGet.Docs/Consume/ProjectJson-Format.md
+++ b/NuGet.Docs/Consume/ProjectJson-Format.md
@@ -12,7 +12,7 @@ The project.json used by NuGet 3 has the following basic shape
       "dependencies": { "PackageId" : "1.0.0" }, 
       "frameworks" : { "TxM" : {} }, 
       "runtimes" : { "RID": {}, "RID": {} }, 
-      "supports" : { "CompatabilityProfile" : {}, "CompatabilityProfile" : {} } 
+      "supports" : { "CompatibilityProfile" : {}, "CompatibilityProfile" : {} } 
     
     }
    


### PR DESCRIPTION
But although this is a misspelling, it's only correct to "fix" it if in fact the product itself doesn't share the misspelling. Does anyone know?