### PR TITLE
[Docs] Versioning - changed "empty" version to indicate the lowest

### DIFF
--- a/NuGet.Docs/Create/Versioning.md
+++ b/NuGet.Docs/Create/Versioning.md
@@ -24,7 +24,7 @@ how to specify version ranges.
     (1.0,) = 1.0 < x
     (1.0,2.0) = 1.0 < x < 2.0
     [1.0,2.0] = 1.0 ≤ x ≤ 2.0
-    empty = latest version.
+    empty = lowest version.
 
 ## Examples
 The following example specifies a dependency on any version of ExamplePackage that begins with a 1 or a 2. 

--- a/NuGet.Docs/Create/Versioning.md
+++ b/NuGet.Docs/Create/Versioning.md
@@ -24,7 +24,17 @@ how to specify version ranges.
     (1.0,) = 1.0 < x
     (1.0,2.0) = 1.0 < x < 2.0
     [1.0,2.0] = 1.0 ≤ x ≤ 2.0
-    empty = lowest version.
+
+When you fail to specify a package version for a dependency as follows:
+
+    <dependency id="ExamplePackage" />
+
+NuGet will perform the following actions:
+
+    NuGet v2.7.2 and earlier - the latest package version will be used
+    NuGet v2.8 and greater - the lowest package version will be used
+
+It is recommended to always specificy a version or version range for package dependencies.
 
 ## Examples
 The following example specifies a dependency on any version of ExamplePackage that begins with a 1 or a 2. 


### PR DESCRIPTION
According to this blog post (http://www.jeffreyfritz.com/2015/12/the-case-of-the-old-nuget-dependency-installation/) when a version is not specified the lowest version is used.  

"Starting with v2.8, NuGet is more conservative by default and will install the lowest version of packages that the package author depends on"

The docs state that the latest version is used which is not correct.