### PR TITLE
Add 'fs' as content language, and document ProjectLanguage matching

### DIFF
--- a/NuGet.Docs/Create/Nuspec-Reference.md
+++ b/NuGet.Docs/Create/Nuspec-Reference.md
@@ -589,7 +589,7 @@ Content shall be stored in the package in folders that match this pattern:
 
 	/contentFiles/{codeLanguage}/{TxM}/{any?}
 
-* codeLanguages may be  `cs`, `vb`, `any`
+* codeLanguages may be  `cs`, `fs`, `vb`, `any` or the lowercase equivalent of a given **$(ProjectLanguage)**
 * TxM is any legal target framework moniker that NuGet supports
 * Any folder structure may be appended to the end of this syntax.
 


### PR DESCRIPTION
Document special casing of 'fs' as content language for F#, and make it clear that codeLanguage can match the lowercase equivalent of the ProjectLanguage property of a given project.
Fixes [#1825](https://github.com/NuGet/Home/issues/1825).