### PR TITLE
Remove deprecated NoPrompt flag from delete documentation

### DIFF
--- a/NuGet.Docs/Consume/Command-Line-Reference.md
+++ b/NuGet.Docs/Consume/Command-Line-Reference.md
@@ -338,7 +338,7 @@ Specify the Id and version of the package to delete from the server.
 
     nuget delete MyPackage 1.0
 
-    nuget delete MyPackage 1.0 -NoPrompt
+    nuget delete MyPackage 1.0 -NonInteractive
 
 ##  List Command
 

--- a/NuGet.Docs/Consume/Command-Line-Reference.md
+++ b/NuGet.Docs/Consume/Command-Line-Reference.md
@@ -312,10 +312,6 @@ Specify the Id and version of the package to delete from the server.
         <td>Specifies the server URL.</td>
     </tr>
     <tr>
-        <td>NoPrompt</td>
-        <td>Do not prompt when deleting.</td>
-    </tr>
-    <tr>
         <td>ApiKey</td>
         <td>The API key for the server.</td>
     </tr>


### PR DESCRIPTION
From nuget.exe printout:
WARNING: Option 'NoPrompt' has been deprecated. Use 'NonInteractive' instead.