### PR TITLE
Update NuGet-2.2.md

### DIFF
--- a/NuGet.Docs/Release-Notes/NuGet-2.2.md
+++ b/NuGet.Docs/Release-Notes/NuGet-2.2.md
@@ -18,7 +18,7 @@ NuGet 2.2 now allows you to specify an entire directory in the `<file>` element 
 
 **`<file src="scripts\" target="content\scripts"/>`**
 
-This feature also enables package authors to easily create empty directories by specifying an empty directory in the NuSpec package. 
+**Update 6/24/16: Empty folders in the "content" folder are ignored when installing the package.**
 
 ## Known Issues
 


### PR DESCRIPTION
Per [Issue#3009](https://github.com/NuGet/Home/issues/3009)
Removed the line "This feature also enables package authors to easily create empty directories by specifying an empty directory in the NuSpec package."
Added a clarification "Empty folders in the "content" folder are ignored when installing the package"