### PR TITLE
Adding versions to -configfile docs to clarify behavior

### DIFF
--- a/NuGet.Docs/ndocs/Consume-Packages/nuget-config-File-Overview.md
+++ b/NuGet.Docs/ndocs/Consume-Packages/nuget-config-File-Overview.md
@@ -202,7 +202,8 @@ Starting with NuGet 3.4, config files are treated in the following priority orde
 	c:\a\b\nuget.config
 	c:\a\nuget.config
 	c:\nuget.config
-	User specific config file, %AppData%\NuGet\nuget.config. 
+	User specific config file, %AppData%\NuGet\nuget.config.
+
 	Or the user specified file thru option `-configfile`.
 
 Starting with NuGet 2.6 upto 3.3, with the new config extensibility point, a new location for machine wide config files located under directory %ProgramData%\NuGet\Config are read after the user specific config file. So, the above list now becomes:

--- a/NuGet.Docs/ndocs/Consume-Packages/nuget-config-File-Overview.md
+++ b/NuGet.Docs/ndocs/Consume-Packages/nuget-config-File-Overview.md
@@ -195,20 +195,17 @@ d) F:\Project2\NuGet.config with content:
 	Closest to the folder nuget.exe runs from wins.
 </div>
 
-NuGet config files are treated in the following priority order, for example assuming the solution directory is c:\a\b\c:
+Starting with NuGet 3.4, config files are treated in the following priority order, for example assuming the solution directory is c:\a\b\c:
 
-	c:\a\b\c\.nuget\nuget.config - Onlyfor solution level packages, and not supported in nuget 3.0+
+	c:\a\b\c\.nuget\nuget.config - Only for solution level packages, and not supported in nuget 3.0+
 	c:\a\b\c\nuget.config
 	c:\a\b\nuget.config
 	c:\a\nuget.config
 	c:\nuget.config
 	User specific config file, %AppData%\NuGet\nuget.config. 
-
 	Or the user specified file thru option `-configfile`.
 
-### Machine Wide Config File
-
-Starting with NuGet 2.6, with the new config extensibility point, a new location for machine wide config files located under directory `%ProgramData%\NuGet\Config` are read after the user specific config file. So, the above list now becomes:
+Starting with NuGet 2.6 upto 3.3, with the new config extensibility point, a new location for machine wide config files located under directory %ProgramData%\NuGet\Config are read after the user specific config file. So, the above list now becomes:
 
 	c:\a\b\c\\.nuget\nuget.config
 		-c:\a\b\c\nuget.config


### PR DESCRIPTION
Adding versions to the -configfile switch docs to have better clarity about the behavior for different versions of nuget.exe

Addresses- https://github.com/NuGet/Home/issues/3208 https://github.com/NuGet/Home/issues/3221

cc : @harikmenon  @karann-msft 
