### PR TITLE
Backwards compatibility error

### DIFF
--- a/NuGet.Docs/ndocs/Create-Packages/Supporting-Multiple-Target-Frameworks.md
+++ b/NuGet.Docs/ndocs/Create-Packages/Supporting-Multiple-Target-Frameworks.md
@@ -98,7 +98,7 @@ For example, given the follow folder structure:
 	        \MyAssembly.dll
 
 If you install a package that has the `lib` folder structure shown in the previous example 
-in a project that targets the .NET Framework 4.6, the assembly in the `net461` folder (for .NET Framework 4.6.1) is selected.
+in a project that targets the .NET Framework 4.6, the assembly in the `net45` folder (for .NET Framework 4.5) is selected.
 
 ## Grouping Assemblies by Framework Version
 


### PR DESCRIPTION
The text explains it correctly:

"the highest version that is less than or equal to the project's target framework"

Although the note below the table states that 4.6.1 would be installed when a 4.6 is targeted.