### PR TITLE
remove ndoc from hyperlink

### DIFF
--- a/NuGet.Docs/ndocs/Schema/nuget.config-file.md
+++ b/NuGet.Docs/ndocs/Schema/nuget.config-file.md
@@ -1,6 +1,6 @@
 # NuGet.Config Reference
 
-NuGet behavior is controlled by settings in `NuGet.Config` files as described in [Configuring NuGet Behavior](ndocs/consume-packages/configuring-nuget-behavior). The individual settings are described in the sections below.
+NuGet behavior is controlled by settings in `NuGet.Config` files as described in [Configuring NuGet Behavior](consume-packages/configuring-nuget-behavior). The individual settings are described in the sections below.
 
 <div class="block-callout-info">
     <strong>Note</strong>


### PR DESCRIPTION
The hyperlink is being built as http://docs.nuget.org/ndocs/schema/ndocs/consume-packages/configuring-nuget-behavior

The node "ndocs" after "schema" should not be there.