### PR TITLE
Added a link to the Non-Microsoft projects section

### DIFF
--- a/NuGet.Docs/ndocs/Policies/Ecosystem.md
+++ b/NuGet.Docs/ndocs/Policies/Ecosystem.md
@@ -39,6 +39,7 @@ Many other individuals and companies have made significant contributions to the 
 * [Sonatype Nexus](http://www.sonatype.com/nexus-repository-sonatype)
 * [SymbolSource](http://www.symbolsource.org/Public)
 * [Xamarin and MonoDevelop](https://github.com/mrward/monodevelop-nuget-addin)
+* [MinimalNugetServer](https://github.com/TanukiSharp/MinimalNugetServer)
 
 
 ## Other NuGet-based utilities

--- a/NuGet.Docs/ndocs/Policies/Ecosystem.md
+++ b/NuGet.Docs/ndocs/Policies/Ecosystem.md
@@ -28,6 +28,7 @@ Many other individuals and companies have made significant contributions to the 
 * [JetBrains ReSharper](https://resharper-plugins.jetbrains.com/)
 * [JetBrains TeamCity](https://www.jetbrains.com/teamcity/)
 * [Klondike](https://github.com/themotleyfool/Klondike)
+* [MinimalNugetServer](https://github.com/TanukiSharp/MinimalNugetServer)
 * [MyGet (or NuGet-as-a-service)](http://www.myget.org/)
 * [NuGet Package Explorer](https://github.com/NuGetPackageExplorer/NuGetPackageExplorer)
 * [NuGet Server](http://nugetserver.net/)
@@ -39,7 +40,6 @@ Many other individuals and companies have made significant contributions to the 
 * [Sonatype Nexus](http://www.sonatype.com/nexus-repository-sonatype)
 * [SymbolSource](http://www.symbolsource.org/Public)
 * [Xamarin and MonoDevelop](https://github.com/mrward/monodevelop-nuget-addin)
-* [MinimalNugetServer](https://github.com/TanukiSharp/MinimalNugetServer)
 
 
 ## Other NuGet-based utilities


### PR DESCRIPTION
As advised by a NuGet team member, I added a link in the `Non-Microsoft projects` section, to a minimal implementation of a NuGet server, self-hostable on any OS thanks to .NET Core.