### PR TITLE
Fix broken formatting

### DIFF
--- a/NuGet.Docs/ndocs/Visual-Studio-Extensibility/Visual-Studio-Templates.md
+++ b/NuGet.Docs/ndocs/Visual-Studio-Extensibility/Visual-Studio-Templates.md
@@ -60,7 +60,6 @@ The VSIX itself can serve as the source for packages required by the template:
     <code class="html">
 		&lt;packages repository="extension"
               repositoryId="MyTemplateContainerExtensionId"&gt;
-
     	&lt;!-- ... --&gt;
     	&lt;/packages&gt;
 	</code>


### PR DESCRIPTION
The formatting here was rendering incorrectly. It looks like just the extra line break was messing things up.

https://docs.nuget.org/ndocs/visual-studio-extensibility/visual-studio-templates