### PR TITLE
Uncapitalize http_proxy and no_proxy environment for Linux users.

### DIFF
--- a/NuGet.Docs/ndocs/Schema/nuget.config-file.md
+++ b/NuGet.Docs/ndocs/Schema/nuget.config-file.md
@@ -57,7 +57,7 @@ Note: `dependencyVersion` and `repositoryPath` apply only to projects using `pac
     </tr>
     <tr>
         <td>http_proxy<br>http_proxy.user<br>http_proxy.password<br>no_proxy</td>
-        <td>Proxy settings to use when connecting to package sources; <code>http_proxy</code> should be in the format <code>http://&lt;username&gt;:&lt;password&gt@&lt;domain&gt</code>. Passwords are encrypted and cannot be added manually. For <code>no_proxy</code>, the value is a comma-separated list of domains the bypass the proxy server. You can alternately use the HTTP_PROXY and NO_PROXY environment variables for those values. For additional details, see <a href="http://skolima.blogspot.com/2012/07/nuget-proxy-settings.html">NuGet proxy settings</a> (skolima.blogspot.com).</td>
+        <td>Proxy settings to use when connecting to package sources; <code>http_proxy</code> should be in the format <code>http://&lt;username&gt;:&lt;password&gt@&lt;domain&gt</code>. Passwords are encrypted and cannot be added manually. For <code>no_proxy</code>, the value is a comma-separated list of domains the bypass the proxy server. You can alternately use the http_proxy and no_proxy environment variables for those values. For additional details, see <a href="http://skolima.blogspot.com/2012/07/nuget-proxy-settings.html">NuGet proxy settings</a> (skolima.blogspot.com).</td>
     </tr>
 </table>
 


### PR DESCRIPTION
The document says we can use ``HTTP_PROXY`` and ``NO_PROXY`` environment variables for proxy configuration. However, on the Linux, capitalized ``HTTP_PROXY`` and ``NO_PROXY`` are not working because NuGet.Client gets environmental variable as the key is small letter ``http_proxy`` and ``no_proxy``.

https://github.com/NuGet/NuGet.Client/blob/4cccb13833ad29d6a0bcff055460d964f1b49cfe/src/NuGet.Core/NuGet.Configuration/Proxy/ProxyCache.cs#L114-L141
https://github.com/NuGet/NuGet.Client/blob/4cccb13833ad29d6a0bcff055460d964f1b49cfe/src/NuGet.Core/NuGet.Configuration/Utility/ConfigurationContants.cs#L34-L40

For the Windows users, this can work because Windows environmental variable key is case insensitive,  but Linux is case sentive. Now .NET Core and Nuget.Core is cross platform, so could you consider Linux users?