### PR TITLE
Enable HSTS header on responses

### DIFF
--- a/NuGet.Docs/Web.config
+++ b/NuGet.Docs/Web.config
@@ -22,6 +22,11 @@
     <pages controlRenderingCompatibilityVersion="4.0"/>
   </system.web>
   <system.webServer>
+    <httpProtocol>
+      <customHeaders>
+        <add name="Strict-Transport-Security" value="max-age=31536000; includeSubDomains" />
+      </customHeaders>
+    </httpProtocol>
     <defaultDocument>
       <files>
         <add value="Default.cshtml"/>


### PR DESCRIPTION
This add the "Strict-Transport-Security" header to responses from this app, enabling browsers that support HSTS (https://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security) to enforce it.

@karann-msft 