### PR TITLE
Remove invalid schema version from .nuspec examples and fix package type

### DIFF
--- a/NuGet.Docs/ndocs/Create-Packages/Creating-a-Package.md
+++ b/NuGet.Docs/ndocs/Create-Packages/Creating-a-Package.md
@@ -46,7 +46,7 @@ A .nuspec is an XML manifest file that describes a package's contents and drives
 Here's typical (but fictitious) `.nuspec` file, with annotation comments:
 
     <?xml version="1.0"?>
-    <package xmlns="http://schemas.microsoft.com/packaging/2016/06/nuspec.xsd">
+    <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
       <metadata>
         <!-- The identifier that must be unique within the hosting gallery -->
         <id>Contoso.Utility.UsefulStuff</id>
@@ -251,7 +251,7 @@ Package types are set either in the `.nuspec` file or in `project.json`. In both
           <metadata>
             <!-- ... -->
             <packageTypes>
-              <packageType type="DotnetCliTool" />
+              <packageType name="DotnetCliTool" />
             </packageTypes>
           </metadata>
         </package>
@@ -270,7 +270,7 @@ Package types are set either in the `.nuspec` file or in `project.json`. In both
 To directly specify files to include in the package, use the **&lt;files&gt;** node in the `.nuspec` file, which *follows* the &lt;metadata&gt; tag:
 
     <?xml version="1.0"?>
-    <package xmlns="http://schemas.microsoft.com/packaging/2016/06/nuspec.xsd">
+    <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
       <metadata>
         <!-- ... -->
       </metadata>

--- a/NuGet.Docs/ndocs/Create-Packages/Dependency-Versions.md
+++ b/NuGet.Docs/ndocs/Create-Packages/Dependency-Versions.md
@@ -5,7 +5,7 @@
 When you [create a NuGet package](creating-a-package), you can specify dependencies for your package in the **&lt;dependencies&gt;** node of the `.nuspec` file, where each dependency is listed with a **&lt;dependency&gt;** tag:
 
     <?xml version="1.0"?>
-    <package xmlns="http://schemas.microsoft.com/packaging/2016/06/nuspec.xsd">
+    <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
       <metadata>
         <!-- ... -->
 


### PR DESCRIPTION
Reporting by user message to feedback (at) nuget (dot) org.

1. The `2016/06` schema version was reverted before releasing. The latest schema is `2013/05`.
1. The package type name attribute is `name` not `type`.

/cc @karann-msft 