### PR TITLE
Improve Depenency-Versions.md readability

### DIFF
--- a/NuGet.Docs/ndocs/Create-Packages/Dependency-Versions.md
+++ b/NuGet.Docs/ndocs/Create-Packages/Dependency-Versions.md
@@ -34,58 +34,18 @@ For additional details on how dependencies are installed, see [Reinstalling and 
 
 NuGet supports using interval notation for specifying version ranges, summarized as follows:
 
-<table>
-    <tr>
-        <th>Notation</th>
-        <th>Applied rule</th>
-        <th>Description</th>
-    </tr>
-    <tr>
-        <td>1.0</td>
-        <td>1.0 ≤ x</td>
-        <td>Minimum version, inclusive</td>
-    </tr>
-    <tr>
-        <td>(1.0,)</td>
-        <td>1.0 < x</td>
-        <td>Mininum version, exclusive</td>
-    </tr>
-    <tr>
-        <td>[1.0]</td>
-        <td>x == 1.0</td>
-        <td>Exact version match</td>
-    </tr>
-    <tr>
-        <td>(,1.0]</td>
-        <td>x ≤ 1.0</td>
-        <td>Maximum version, inclusive</td>
-    </tr>
-    <tr>
-        <td>(,1.0)</td>
-        <td>x < 1.0</td>
-        <td>Maximum version, exclusive</td>
-    </tr>
-    <tr>
-        <td>[1.0,2.0]</td>
-        <td>1.0 ≤ x ≤ 2.0</td>
-        <td>Exact range, inclusive</td>
-    </tr>
-    <tr>
-        <td>(1.0,2.0)</td>
-        <td>1.0 < x < 2.0</td>
-        <td>Exact range, exclusive</td>
-    </tr>
-    <tr>
-        <td>[1.0,2.0)</td>
-        <td>1.0 ≤ x < 2.0</td>
-        <td>Mixed inclusive minimum and exclusive maximum version</td>
-    </tr>
-    <tr>
-        <td>(1.0)</td>
-        <td>invalid</td>
-        <td>invalid</td>
-    </tr>
-</table>
+Notation   | Applied rule    | Description
+-----------|-----------------|------------------------------
+1.0        |  1.0 ≤ x        |  Minimum version, inclusive
+(1.0,)      |  1.0 < x        |  Mininum version, exclusive
+[1.0]      |  x == 1.0       |  Exact version match
+(,1.0]     |  x ≤ 1.0        |  Maximum version, inclusive
+(,1.0)     |  x < 1.0        |  Maximum version, exclusive
+[1.0,2.0]  |  1.0 ≤ x ≤ 2.0  |  Exact range, inclusive
+(1.0,2.0)  |  1.0 < x < 2.0  |  Exact range, exclusive
+[1.0,2.0)  |  1.0 ≤ x < 2.0  |  Mixed inclusive minimum and exclusive maximum version
+(1.0)      |  invalid        |  invalid
+
 
 
 A few examples:


### PR DESCRIPTION
Make Depenency-Versions.md more readible by reformatting the table. Using markdown |--| table syntax instead of <table>. This also fixes the table formatting error on https://docs.nuget.org/ndocs/create-packages/dependency-versions.